### PR TITLE
Fix crashiness caused by trying to access a nil object

### DIFF
--- a/assessment/cha2ds2_vsac_score_test.go
+++ b/assessment/cha2ds2_vsac_score_test.go
@@ -24,8 +24,8 @@ var _ = Suite(&CHADSSuite{})
 
 func (cs *CHADSSuite) SetUpSuite(c *C) {
 	data, err := os.Open("fixtures/condition_bundle.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(data)
 	jsonString := buf.String()

--- a/fhir/fhir_requests.go
+++ b/fhir/fhir_requests.go
@@ -17,10 +17,10 @@ func GetCountForPatientResources(fhirEndpointUrl, resource, patientId string) (i
 
 func GetCount(fullFhirUrl string) (int, error) {
 	resp, err := http.Get(fullFhirUrl)
-	defer resp.Body.Close()
 	if err != nil {
 		return 0, errors.New(fmt.Sprintf("Could not get: %s", fullFhirUrl))
 	}
+	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 	bundle := &models.Bundle{}
 	err = decoder.Decode(bundle)
@@ -33,10 +33,10 @@ func GetCount(fullFhirUrl string) (int, error) {
 
 func GetPatientConditions(fullFhirUrl string, ts time.Time) ([]*models.Condition, error) {
 	resp, err := http.Get(fullFhirUrl)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Could not get: %s", fullFhirUrl))
 	}
+	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 	bundle := &models.Bundle{}
 	err = decoder.Decode(bundle)
@@ -68,10 +68,10 @@ func getConditionStart(c *models.Condition) *models.FHIRDateTime {
 
 func GetPatientMedicationStatements(fullFhirUrl string, ts time.Time) ([]*models.MedicationStatement, error) {
 	resp, err := http.Get(fullFhirUrl)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Could not get: %s", fullFhirUrl))
 	}
+	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 	bundle := &models.Bundle{}
 	err = decoder.Decode(bundle)
@@ -102,10 +102,10 @@ func getMedicationStatementStart(med *models.MedicationStatement) *models.FHIRDa
 
 func GetPatient(fullFhirUrl string) (*models.Patient, error) {
 	resp, err := http.Get(fullFhirUrl)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Could not get: %s", fullFhirUrl))
 	}
+	defer resp.Body.Close()
 	decoder := json.NewDecoder(resp.Body)
 	patient := &models.Patient{}
 	err = decoder.Decode(patient)


### PR DESCRIPTION
While `defer resp.Body.Close()` is generally _good_, it's important to call it only after you've verified that `resp.Body` was successfully opened in the first place.  Otherwise, you're trying to call a function on a nil object.
