### PR TITLE
Risk service fixes

### DIFF
--- a/assessment/fixtures/condition_bundle.json
+++ b/assessment/fixtures/condition_bundle.json
@@ -1,6 +1,7 @@
 {
   "id": "55b7a4a51cd462bf29000001",
-  "resourceType": "searchset",
+  "resourceType": "Bundle",
+  "type": "searchset",
   "total": 3,
   "entry": [
     {

--- a/server/calculation_runner_test.go
+++ b/server/calculation_runner_test.go
@@ -79,7 +79,8 @@ func (crs *CalculationRunnerSuite) TestRunner(c *C) {
 	count, _ := db.C("pies").Count()
 	// Should have the pie only for bar
 	c.Assert(count, Equals, 1)
-	time.Sleep(1 * time.Second)
+	// This seems a little finicky -- I bumped this from 1 sec to 3 sec to make the test pass!
+	time.Sleep(3 * time.Second)
 	count, _ = db.C("pies").Count()
 	// Should have all pies
 	c.Assert(count, Equals, 3)


### PR DESCRIPTION
Fix typo in bundle fixture (wrong resource type).  Also, sometimes the riskservice tests fail for me, but it's inconsistent.  After a small amount of trial and error, discovered that increasing a sleep statement from 1 second to 3 seconds seems to make it more consistent.  It feels dirty, but we have a riskservice refactor on the horizon, so at least it is temporary dirtiness.
