### PR TITLE
Support for Not Applicable Risk Assessments

### DIFF
--- a/assessments/cha2ds2_vasc_plugin.go
+++ b/assessments/cha2ds2_vasc_plugin.go
@@ -45,21 +45,18 @@ func (c *CHA2DS2VAScPlugin) Config() plugin.RiskServicePluginConfig {
 func (c *CHA2DS2VAScPlugin) Calculate(es *plugin.EventStream, fhirEndpointURL string) ([]plugin.RiskServiceCalculationResult, error) {
 	var results []plugin.RiskServiceCalculationResult
 
-	// COMMENTED OUT because frontend does not properly handle patients w/ no RiskAssessments,
-	// so we must proceed with at least on RiskAssessment of score 0 until "not applicable" is supported
-	//
-	// // First make sure there is AFIB in the history, since this score is only valid for patients with AFIB
-	// var hasAFib bool
-	// for i := 0; !hasAFib && i < len(es.Events); i++ {
-	// 	if es.Events[i].Type == "Condition" && !es.Events[i].End {
-	// 		if cond, ok := es.Events[i].Value.(*models.Condition); ok {
-	// 			hasAFib = fuzzyFindCondition("427.31", "http://hl7.org/fhir/sid/icd-9", cond)
-	// 		}
-	// 	}
-	// }
-	// if !hasAFib {
-	// 	return nil, plugin.NewNotApplicableError("CHA2DS2-VASc is only applicable to patients with Atrial Fibrillation")
-	// }
+	// First make sure there is AFIB in the history, since this score is only valid for patients with AFIB
+	var hasAFib bool
+	for i := 0; !hasAFib && i < len(es.Events); i++ {
+		if es.Events[i].Type == "Condition" && !es.Events[i].End {
+			if cond, ok := es.Events[i].Value.(*models.Condition); ok {
+				hasAFib = fuzzyFindCondition("427.31", "http://hl7.org/fhir/sid/icd-9", cond)
+			}
+		}
+	}
+	if !hasAFib {
+		return nil, plugin.NewNotApplicableError("CHA2DS2-VASc is only applicable to patients with Atrial Fibrillation")
+	}
 
 	// Create the initial pie based on gender
 	pie := plugin.NewPie(fhirEndpointURL + "/Patient/" + es.Patient.Id)
@@ -124,20 +121,6 @@ func (c *CHA2DS2VAScPlugin) Calculate(es *plugin.EventStream, fhirEndpointURL st
 				Pie:                pie,
 			})
 		}
-	}
-
-	// If there are no results, provide a 0 score for the current time
-	if len(results) == 0 {
-		zero := 0
-		zeroFlt := 0.0
-		defaultPie := plugin.NewPie(fhirEndpointURL + "/Patient/" + es.Patient.Id)
-		defaultPie.Slices = c.Config().DefaultPieSlices
-		results = append(results, plugin.RiskServiceCalculationResult{
-			AsOf:               time.Now(),
-			Score:              &zero,
-			ProbabilityDecimal: &zeroFlt,
-			Pie:                defaultPie,
-		})
 	}
 
 	return results, nil

--- a/assessments/cha2ds2_vasc_plugin_test.go
+++ b/assessments/cha2ds2_vasc_plugin_test.go
@@ -166,20 +166,10 @@ func (cs *CHA2DS2VAScPluginSuite) TestNoAFib(c *C) {
 	es.Events = append(es.Events, ageEvent("5", 75, time.Date(2015, time.July, 1, 0, 0, 0, 0, time.UTC)))
 	results, err := cs.Plugin.Calculate(es, cs.FHIREndpointURL)
 
-	// COMMENTED OUT:  While this is the INTENDED design, the frontend currently does not support it.
-	// Instead we must return a single result with score 0.
-	// c.Assert(err, NotNil)
-	// c.Assert(err, FitsTypeOf, plugin.NotApplicableError{})
-	// c.Assert(err.Error(), Equals, "CHA2DS2-VASc is only applicable to patients with Atrial Fibrillation")
-	// c.Assert(results, HasLen, 0)
-
-	// TODO: Remove these assertions and uncomment above when frontend supports N/A
-	c.Assert(err, IsNil)
-	c.Assert(results, HasLen, 1)
-	obtainedDt := results[0].AsOf
-	c.Assert(time.Since(obtainedDt).Minutes() < 1.0, Equals, true)
-	cs.assertResult(c, results[0], obtainedDt, 0, 0, "1223", 0, 0, 0, 0, 0, 0, 0)
-
+	c.Assert(err, NotNil)
+	c.Assert(err, FitsTypeOf, plugin.NotApplicableError{})
+	c.Assert(err.Error(), Equals, "CHA2DS2-VASc is only applicable to patients with Atrial Fibrillation")
+	c.Assert(results, HasLen, 0)
 }
 
 func (cs *CHA2DS2VAScPluginSuite) assertResult(c *C, result plugin.RiskServiceCalculationResult, asOf time.Time, score int, pct float64, patientID string, chf, hypertension, diabetes, stroke, vasc, age, gender int) {


### PR DESCRIPTION
Represents _Not Applicable_ risk assessments with a Prediction.ProbabilityCodeableConcept having the SNOMED code for _not applicable_.  This allows UI's (like the IE frontend) to more accurately display the risk information as not applicable.
